### PR TITLE
new min score

### DIFF
--- a/psl_proof/models/verification_dtos.py
+++ b/psl_proof/models/verification_dtos.py
@@ -8,3 +8,4 @@ class VerifyTokenResult:
     error_text: str
     proof_token: str
     cooldown_period_hours: float = 0  # Cooldown period from backend config
+    minimum_score: float = 0  # Minimum score threshold from backend config

--- a/psl_proof/proof.py
+++ b/psl_proof/proof.py
@@ -51,7 +51,7 @@ class Proof:
         )
         is_data_authentic = verify_result
         cooldown_period_hours = 4  # Safe default
-        minimum_score = 0.0001  # Safe default
+        minimum_score = 0.0001  # Safe default. 0.01 / 100
         if is_data_authentic:
             #print(f"verify_result: {verify_result}")
             is_data_authentic = verify_result.is_valid

--- a/psl_proof/proof.py
+++ b/psl_proof/proof.py
@@ -51,6 +51,7 @@ class Proof:
         )
         is_data_authentic = verify_result
         cooldown_period_hours = 4  # Safe default
+        minimum_score = 0.0001  # Safe default
         if is_data_authentic:
             #print(f"verify_result: {verify_result}")
             is_data_authentic = verify_result.is_valid
@@ -59,6 +60,9 @@ class Proof:
             # Only use backend cooldown if provided (> 0), otherwise keep safe default
             if verify_result.cooldown_period_hours > 0:
                 cooldown_period_hours = verify_result.cooldown_period_hours
+            # Only use backend minimum score if provided (> 0), otherwise keep safe default
+            if verify_result.minimum_score > 0:
+                minimum_score = verify_result.minimum_score
 
         cargo_data = CargoData(
             source_data = source_data,
@@ -138,7 +142,7 @@ class Proof:
         total_score = min(evaluate_result.score, maximum_score)
         print(f"Scores >> Quality: {self.proof_response.quality:.4f} | Uniqueness: {self.proof_response.uniqueness:.4f} | Total: {total_score:.4f} (Q×U)")
 
-        minimum_score = 0.0005  # 0.05 / 100
+        # minimum_score is set earlier from backend config (default: 0.0001)
         self.proof_response.valid = True
         self.proof_response.score = max(minimum_score, min(total_score, maximum_score))
 

--- a/psl_proof/utils/verification.py
+++ b/psl_proof/utils/verification.py
@@ -25,7 +25,8 @@ def verify_token(config: Dict[str, Any], source_data: SourceData) -> Optional[Ve
                     is_valid=result_json.get("isValid", False),
                     error_text=result_json.get("errorText", ""),
                     proof_token=result_json.get("proofToken", ""),
-                    cooldown_period_hours=result_json.get("cooldownPeriodHours", 0)
+                    cooldown_period_hours=result_json.get("cooldownPeriodHours", 0),
+                    minimum_score=result_json.get("minimumScore", 0)
                 )
                 return result
             except ValueError as e:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `minimum_score` from verification API and uses it (with a safe default) as the floor for computed proof scores.
> 
> - **Add `minimum_score` to verification flow:** Extend `VerifyTokenResult` with `minimum_score` and parse `minimumScore` from the verification API response.
> - **Enforce score floor in `proof.py`:** Initialize a safe default `minimum_score` (0.0001), override with backend value when > 0, and set `proof_response.score = max(minimum_score, total_score)`; remove previous hardcoded minimum (0.0005).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4fe34ce60778e2f0db2dafcc1f988e71d3ba171. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->